### PR TITLE
InflationLayer: Better Radius Parameter Limits + Standard Decay Function

### DIFF
--- a/mesh_layers/include/mesh_layers/inflation_layer.h
+++ b/mesh_layers/include/mesh_layers/inflation_layer.h
@@ -112,7 +112,7 @@ class InflationLayer : public mesh_map::AbstractLayer
    *
    * @return resulting cost value
    */
-  float fading(const float val);
+  float fading(const float squared_distance);
 
   /**
    * @brief inflate around lethal vertices by using an wave front propagation and assign riskiness values to vertices

--- a/mesh_layers/src/inflation_layer.cpp
+++ b/mesh_layers/src/inflation_layer.cpp
@@ -238,10 +238,7 @@ float InflationLayer::fading(const float squared_distance)
   // <= Inflation radius
   if (distance > config_.inscribed_radius) 
   {
-    // Map values from [config_.inscribed_radius, config_.inflation_radius] to [0, pi]
-    // float alpha = ((dist - config_.inscribed_radius) / (config_.inflation_radius - config_.inscribed_radius)) * M_PI;
-    // return config_.inscribed_value * (cos(alpha) + 1) / 2.0;
-
+    // http://wiki.ros.org/costmap_2d - cost decay function
     const float factor = exp(-1.0f * config_.cost_scaling_factor * (distance - config_.inscribed_radius));
     const float cost = config_.inscribed_value * factor;
     return cost;


### PR DESCRIPTION
I made some changes to the inflation layer. I
1. increased the range limits for radius parameters  
2. replaced the cosine cost decay function with the standard `costmap2d` function for better comparability
3. removed unused functions