### PR TITLE
Move cost layer publishing responsibility to the layer manager

### DIFF
--- a/mesh_map/include/mesh_map/mesh_map.h
+++ b/mesh_map/include/mesh_map/mesh_map.h
@@ -143,15 +143,9 @@ public:
    * @brief Publishes the given vertex map as mesh_msgs/VertexCosts, e.g. to visualize these.
    * @param costs The cost map to publish
    * @param name The name of the cost map
+   * @param timestamp The timestamp of the costmap
    */
   void publishVertexCosts(const lvr2::VertexMap<float>& costs, const std::string& name, const rclcpp::Time& map_stamp);
-
-  /**
-   * @brief Publishes the given vertex map as mesh_msgs/VertexCostsSparse, e.g. to update the visualization in RVIZ.
-   * @param costs The cost map to publish
-   * @param name The name of the cost map
-   */
-  void publishVertexCostsUpdate(const lvr2::VertexMap<float>& costs, const float default_value, const std::string& name, const rclcpp::Time& map_stamp);
 
   /**
    * @briefP Publishes the vertex colors if these exists.
@@ -528,12 +522,6 @@ private:
 
   //! vertex normals
   lvr2::DenseVertexMap<Normal> vertex_normals;
-
-  //! publisher for vertex costs
-  rclcpp::Publisher<mesh_msgs::msg::MeshVertexCostsStamped>::SharedPtr vertex_costs_pub;
-  rclcpp::TimerBase::SharedPtr vertex_costs_subscribe_checker_;
-  size_t vertex_costs_sub_count_ = 0;
-  rclcpp::Publisher<mesh_msgs::msg::MeshVertexCostsSparseStamped>::SharedPtr vertex_costs_update_pub_;
 
   //! publisher for vertex colors
   rclcpp::Publisher<mesh_msgs::msg::MeshVertexColorsStamped>::SharedPtr vertex_colors_pub;

--- a/mesh_map/test/mesh_map_test.cpp
+++ b/mesh_map/test/mesh_map_test.cpp
@@ -44,7 +44,7 @@ TEST_F(MeshMapTest, loadsSinglePlugin)
   // The MeshMap requires that a map file is loaded to initialize, so we test the layer manager directly
   mesh_map::LayerManager manager(*mesh_map_ptr_, node_ptr_);
 
-  EXPECT_NO_THROW(manager.read_configured_layers(node_ptr_));
+  EXPECT_NO_THROW(manager.read_configured_layers());
   EXPECT_TRUE(manager.load_layer_plugins(node_ptr_->get_logger()));
   // This calls back to the mesh map and segfaults because the MeshMap has its own internal LayerManager :(
   // EXPECT_TRUE(manager.initialize_layer_plugins(node_ptr_, mesh_map_ptr_));
@@ -65,7 +65,7 @@ TEST_F(MeshMapTest, loadsMultiplePlugins)
   // The MeshMap requires that a map file is loaded to initialize, so we test the layer manager directly
   mesh_map::LayerManager manager(*mesh_map_ptr_, node_ptr_);
 
-  EXPECT_NO_THROW(manager.read_configured_layers(node_ptr_));
+  EXPECT_NO_THROW(manager.read_configured_layers());
   EXPECT_TRUE(manager.load_layer_plugins(node_ptr_->get_logger()));
 
   EXPECT_NE(manager.get_layer("t1"), nullptr);


### PR DESCRIPTION
This change allows us to set the vertex cost publisher's queue size to the number of configured layers. This fixes a bug where RViz on a networked computer would not receive some cost maps when the cost maps are published in rapid succession.
This happens because the cost layers are removed from the publisher queue before RViz has received them.

The `publishVertexCostsUpdate` function is removed from the MeshMap's interface because it is no longer needed.
The `publishVertexCosts` function is used by the CVP planner to publish the `Potential` cost layer so we cannot remove this method without loosing functionality.