### PR TITLE
Use vertex's normal to define the local plane for height diff calculation

### DIFF
--- a/mesh_layers/src/height_diff_layer.cpp
+++ b/mesh_layers/src/height_diff_layer.cpp
@@ -104,7 +104,8 @@ bool HeightDiffLayer::computeLayer()
 {
   auto map = map_ptr_.lock();
   auto mesh = map->mesh();
-  height_diff_ = lvr2::calcVertexHeightDifferences(*mesh, config_.radius);
+  const auto& normals = map->vertexNormals();
+  height_diff_ = lvr2::calcVertexHeightDifferences(*mesh, normals, config_.radius);
   return computeLethals();
 }
 


### PR DESCRIPTION
This PR depends on https://github.com/uos/lvr2/pull/56.

Using the plane defined by the vertex's normal for height difference calculation leads to a better detection of spikes or similar features on the ground, while keeping smooth sloped areas at low costs. To prevent the robot  from driving through too steep areas the `SteepnessLayer` should be used.