### PR TITLE
fix: InflationLayer::fading(float) expected the squared distance

### DIFF
--- a/mesh_layers/src/inflation_layer.cpp
+++ b/mesh_layers/src/inflation_layer.cpp
@@ -312,10 +312,8 @@ bool InflationLayer::waveFrontUpdate(
   return false;
 }
 
-float InflationLayer::fading(const float squared_distance)
+float InflationLayer::fading(const float distance)
 {
-  const float distance = sqrt(squared_distance);
-
   if (distance > config_.inflation_radius)
   {
     return 0;

--- a/mesh_layers/test/inflation_layer_test.cpp
+++ b/mesh_layers/test/inflation_layer_test.cpp
@@ -7,9 +7,10 @@ using mesh_map::Vector;
 lvr2::PMPMesh<mesh_map::Vector> genTriangle()
 {
     lvr2::PMPMesh<mesh_map::Vector> mesh;
+    // Using 0.5 instead of 1.0 because distances of 1.0 cannot be differentiated from squared distance of 1.0
     mesh.addVertex(Vector(0, 0, 0));  // Vertex 0
-    mesh.addVertex(Vector(1, 0, 0));  // Vertex 1
-    mesh.addVertex(Vector(0, 1, 0));  // Vertex 2
+    mesh.addVertex(Vector(0.5, 0, 0));  // Vertex 1
+    mesh.addVertex(Vector(0, 0.5, 0));  // Vertex 2
 
     // Create face (triangle) using the three vertices
     mesh.addFace(
@@ -37,6 +38,11 @@ lvr2::DenseEdgeMap<float> calcEdgeWeights(const lvr2::PMPMesh<Vector>& mesh)
 TEST(InflationLayer, test_wave_front_update)
 {
     mesh_layers::InflationLayer instance;
+    instance.config_.inflation_radius = 1.5;
+    instance.config_.inscribed_radius = 0.5;
+    instance.config_.lethal_value = 1.0;
+    instance.config_.inscribed_value = 0.9;
+    instance.config_.cost_scaling_factor = 1.0;
 
     //=== Set up test data ===//
     lvr2::PMPMesh<mesh_map::Vector> mesh = genTriangle();
@@ -65,7 +71,30 @@ TEST(InflationLayer, test_wave_front_update)
     ));
 
     // The distance of vertex 2 to the origin of the wave front (vertex 0)
-    // should be equal to their distance -> 1.0
+    // should be equal to their distance -> 0.5
     const float distance = distances[lvr2::VertexHandle(2)];
-    EXPECT_FLOAT_EQ(distance, 1.0f);
+    EXPECT_FLOAT_EQ(distance, 0.5f);
+
+    // Fading of 0.5 should be 0.9
+    EXPECT_FLOAT_EQ(instance.fading(distance), instance.config_.inscribed_value);
+}
+
+
+TEST(InflationLayer, test_fading)
+{
+    mesh_layers::InflationLayer instance;
+    instance.config_.inflation_radius = 1.5;
+    instance.config_.inscribed_radius = 0.5;
+    instance.config_.lethal_value = 1.0;
+    instance.config_.inscribed_value = 0.9;
+    instance.config_.cost_scaling_factor = 1.0;
+
+    // Inside the inscribed_radius
+    EXPECT_FLOAT_EQ(instance.fading(0.2), 0.9);
+    // Inside the inflation radius should be less than inscribed
+    EXPECT_LT(instance.fading(0.6), 0.9);
+    // But greater than 0
+    EXPECT_GT(instance.fading(0.6), 0.0);
+    // Outside inflation radius should be 0
+    EXPECT_FLOAT_EQ(instance.fading(2.0), 0.0);
 }


### PR DESCRIPTION
InflationLayer::fading(float) expected the squared distance but the waveFrontUpdate() computes the actual distance. This let to the inscribed radius being smaller than configured and the robot crashing into obstacles.