### PR TITLE
Simplify MeshNav Server

### DIFF
--- a/mbf_mesh_nav/CMakeLists.txt
+++ b/mbf_mesh_nav/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(ament_cmake_ros REQUIRED)
 set(dependencies
   geometry_msgs
   mbf_abstract_nav
+  mbf_abstract_core
+  mbf_simple_nav
   mbf_simple_core
   mbf_mesh_core
   mbf_msgs

--- a/mbf_mesh_nav/include/mbf_mesh_nav/mesh_navigation_server.h
+++ b/mbf_mesh_nav/include/mbf_mesh_nav/mesh_navigation_server.h
@@ -40,7 +40,8 @@
 
 #include <mutex>
 
-#include <mbf_abstract_nav/abstract_navigation_server.h>
+
+#include <mbf_simple_nav/simple_navigation_server.h>
 
 #include "mesh_controller_execution.h"
 #include "mesh_planner_execution.h"
@@ -54,6 +55,14 @@
 #include <mbf_simple_core/simple_planner.h>
 #include <mbf_simple_core/simple_controller.h>
 #include <mbf_simple_core/simple_recovery.h>
+
+#include <mbf_abstract_nav/abstract_planner_execution.h>
+#include <mbf_abstract_nav/abstract_controller_execution.h>
+#include <mbf_abstract_nav/abstract_recovery_execution.h>
+
+#include <mbf_abstract_core/abstract_planner.h>
+#include <mbf_abstract_core/abstract_controller.h>
+#include <mbf_abstract_core/abstract_recovery.h>
 
 #include <pluginlib/class_loader.hpp>
 
@@ -75,12 +84,14 @@ namespace mbf_mesh_nav
  *
  * @ingroup navigation_server move_base_server
  */
-class MeshNavigationServer : public mbf_abstract_nav::AbstractNavigationServer
+class MeshNavigationServer : public mbf_simple_nav::SimpleNavigationServer
 {
 public:
   typedef std::shared_ptr<mesh_map::MeshMap> MeshPtr;
 
   typedef std::shared_ptr<MeshNavigationServer> Ptr;
+
+  using Base = mbf_simple_nav::SimpleNavigationServer;
 
   /**
    * @brief Constructor
@@ -95,18 +106,17 @@ public:
 
   virtual void stop();
 
-private:
   //! shared pointer to a new @ref planner_execution "PlannerExecution"
   virtual mbf_abstract_nav::AbstractPlannerExecution::Ptr
-  newPlannerExecution(const std::string &plugin_name, const mbf_abstract_core::AbstractPlanner::Ptr plugin_ptr);
+    newPlannerExecution(const std::string &plugin_name, const mbf_abstract_core::AbstractPlanner::Ptr plugin_ptr);
 
   //! shared pointer to a new @ref controller_execution "ControllerExecution"
   virtual mbf_abstract_nav::AbstractControllerExecution::Ptr
-  newControllerExecution(const std::string &plugin_name, const mbf_abstract_core::AbstractController::Ptr plugin_ptr);
+    newControllerExecution(const std::string &plugin_name, const mbf_abstract_core::AbstractController::Ptr plugin_ptr);
 
   //! shared pointer to a new @ref recovery_execution "RecoveryExecution"
   virtual mbf_abstract_nav::AbstractRecoveryExecution::Ptr
-  newRecoveryExecution(const std::string &plugin_name, const mbf_abstract_core::AbstractRecovery::Ptr plugin_ptr);
+    newRecoveryExecution(const std::string &plugin_name, const mbf_abstract_core::AbstractRecovery::Ptr plugin_ptr);
 
   /**
    * @brief Loads the plugin associated with the given planner_type parameter.
@@ -190,17 +200,15 @@ private:
    */
   void callServiceClearMesh(std::shared_ptr<rmw_request_id_t> request_header, std::shared_ptr<std_srvs::srv::Empty::Request> request, std::shared_ptr<std_srvs::srv::Empty::Response> response);
 
+private:
   //! plugin class loader for recovery behaviors plugins
   pluginlib::ClassLoader<mbf_mesh_core::MeshRecovery> recovery_plugin_loader_;
-  pluginlib::ClassLoader<mbf_simple_core::SimpleRecovery> simple_recovery_plugin_loader_;
 
   //! plugin class loader for controller plugins
   pluginlib::ClassLoader<mbf_mesh_core::MeshController> controller_plugin_loader_;
-  pluginlib::ClassLoader<mbf_simple_core::SimpleController> simple_controller_plugin_loader_;
-
+ 
   //! plugin class loader for planner plugins
   pluginlib::ClassLoader<mbf_mesh_core::MeshPlanner> planner_plugin_loader_;
-  pluginlib::ClassLoader<mbf_simple_core::SimplePlanner> simple_planner_plugin_loader_;
 
   //! Shared pointer to the common global mesh
   MeshPtr mesh_ptr_;

--- a/mbf_mesh_nav/package.xml
+++ b/mbf_mesh_nav/package.xml
@@ -14,6 +14,8 @@
 
     <depend>geometry_msgs</depend>
     <depend>mbf_abstract_nav</depend>
+    <depend>mbf_abstract_core</depend>
+    <depend>mbf_simple_nav</depend>
     <depend>mbf_simple_core</depend>
     <depend>mbf_mesh_core</depend>
     <depend>mbf_msgs</depend>

--- a/mbf_mesh_nav/src/mbf_mesh_nav.cpp
+++ b/mbf_mesh_nav/src/mbf_mesh_nav.cpp
@@ -63,8 +63,9 @@ int main(int argc, char** argv)
 
   TFPtr tf_buffer_ptr = std::make_shared<TF>(node->get_clock(), tf2::durationFromSec(cache_time));
   tf2_ros::TransformListener tf_listener(*tf_buffer_ptr);
+  RCLCPP_INFO_STREAM(node->get_logger(), "Starting mesh navigation server.");
   mesh_nav_srv_ptr = std::make_shared<mbf_mesh_nav::MeshNavigationServer>(tf_buffer_ptr, node);
-
+  // mesh_nav_srv_ptr->initializeServerComponents();
   signal(SIGINT, sigintHandler);
 
   // NOTE: Using a multithreaded executor is recommended so cost layers can use

--- a/mbf_mesh_nav/src/mbf_mesh_nav.cpp
+++ b/mbf_mesh_nav/src/mbf_mesh_nav.cpp
@@ -65,7 +65,6 @@ int main(int argc, char** argv)
   tf2_ros::TransformListener tf_listener(*tf_buffer_ptr);
   RCLCPP_INFO_STREAM(node->get_logger(), "Starting mesh navigation server.");
   mesh_nav_srv_ptr = std::make_shared<mbf_mesh_nav::MeshNavigationServer>(tf_buffer_ptr, node);
-  // mesh_nav_srv_ptr->initializeServerComponents();
   signal(SIGINT, sigintHandler);
 
   // NOTE: Using a multithreaded executor is recommended so cost layers can use

--- a/mbf_mesh_nav/src/mesh_navigation_server.cpp
+++ b/mbf_mesh_nav/src/mesh_navigation_server.cpp
@@ -66,7 +66,7 @@ MeshNavigationServer::MeshNavigationServer(const TFPtr& tf_listener_ptr, const r
   RCLCPP_INFO_STREAM(node_->get_logger(), "Reading map file...");
   mesh_ptr_->readMap();
 
-  // initialize all plugins (done by SimpleNavigationServer constructor) and then initialize the server components (e.g. services) that depend on the plugins to be loaded and initialized
+  // initialize all plugins (also done by SimpleNavigationServer constructor) and then initialize the server components (e.g. services) that depend on the plugins to be loaded and initialized
   initializeServerComponents();
 }
 

--- a/mbf_mesh_nav/src/mesh_navigation_server.cpp
+++ b/mbf_mesh_nav/src/mesh_navigation_server.cpp
@@ -45,98 +45,15 @@
 #include <nav_msgs/msg/path.hpp>
 #include <rclcpp/logging.hpp>
 
-namespace {
-//! Helper function, intended for formatting available plugin types.
-//! Returns a string like this: [el1, el2, el3, ..., eln]
-std::string stringVectorToString(const std::vector<std::string>& vec) 
-{
-  std::stringstream s;
-  s << "[";
-  bool is_first = true;
-  for (const auto& item : vec)
-  {
-    s << (is_first ? "" : ", ") << item;
-    is_first = false;
-  }
-  s << "]";
-  return s.str();
-};
-
-/*!
- * Helper function to reduce code duplication when loading plugins.
- * CorePluginTypes can be either planners, controllers or recovery behaviors.
- * @tparam AbstractCorePluginType AbstractCore type of the plugin to load. Needs to be the base class of SimpleCorePluginType and MeshCorePluginType. E.g. mbf_abstract_core::AbstractPlanner.
- * @tparam SimpleCorePluginType SimpleCore type of the plugin to load. E.g. mbf_simple_core::SimplePlanner
- * @tparam MeshCorePluginType MeshCore type of the plugin to load. E.g. mbf_simple_core::MeshPlanner
- * @param plugin_type typename of the plugin that shall be loaded, usually configured by user via ros params.
- * @param which_plugin_kind should be "planner", "controller", or "recovery behavior", used only for nicer logging messages.
- */
-template<typename AbstractCorePluginType, typename MeshCorePluginType, typename SimpleCorePluginType>
-typename AbstractCorePluginType::Ptr loadPlugin(const std::string& plugin_type, pluginlib::ClassLoader<MeshCorePluginType>& mesh_plugin_loader, pluginlib::ClassLoader<SimpleCorePluginType>& simple_plugin_loader, const std::string& which_plugin_kind, rclcpp::Logger logger)
-{
-  // support both simple core and mesh core plugins. We cannot see which type a plugin is from planner_type, so we need to rely on try catch.
-  const auto available_mesh_plugins= mesh_plugin_loader.getDeclaredClasses();
-  const auto available_simple_plugins = simple_plugin_loader.getDeclaredClasses();
-
-  typename AbstractCorePluginType::Ptr plugin_ptr;
-  std::string plugin_name;
-  if (std::find(available_mesh_plugins.begin(), available_mesh_plugins.end(), plugin_type) != available_mesh_plugins.end())
-  {
-    // plugin_type is available as mesh plugin
-    try
-    {
-      plugin_ptr = std::dynamic_pointer_cast<AbstractCorePluginType>(mesh_plugin_loader.createSharedInstance(plugin_type));
-      plugin_name = mesh_plugin_loader.getName(plugin_type);
-    }
-    catch (const pluginlib::PluginlibException& ex_mbf_core)
-    {
-      RCLCPP_ERROR_STREAM(logger, "Error while loading " << plugin_type << " as mesh " << which_plugin_kind << ": " << ex_mbf_core.what());
-    }
-  }
-  else if (std::find(available_simple_plugins.begin(), available_simple_plugins.end(), plugin_type) != available_simple_plugins.end())
-  {
-    // plugin_type is available as simple plugin
-    try 
-    {
-      plugin_ptr = std::dynamic_pointer_cast<AbstractCorePluginType>(simple_plugin_loader.createSharedInstance(plugin_type));
-      plugin_name = simple_plugin_loader.getName(plugin_type);
-    }
-    catch (const pluginlib::PluginlibException& ex_mbf_core)
-    {
-      RCLCPP_ERROR_STREAM(logger, "Error while loading " << plugin_type << " as simple " << which_plugin_kind << ": " << ex_mbf_core.what());
-    }
-  }
-  else
-  {
-    // plugin was not found
-    RCLCPP_ERROR_STREAM(logger, "Failed to find the " << plugin_type << " " << which_plugin_kind << ". "
-                                << "Are you sure it's properly registered and that the containing library is built? "
-                                << "Registered mesh " << which_plugin_kind << " are: " << stringVectorToString(available_mesh_plugins)
-                                << ". Registered simple " << which_plugin_kind << " are: " << stringVectorToString(available_simple_plugins));
-  }
-
-  if (plugin_ptr) 
-  {
-    // success
-    RCLCPP_DEBUG_STREAM(logger, "mbf_mesh_core-based " << which_plugin_kind << " plugin " << plugin_name << " loaded.");
-  }
-  return plugin_ptr; // return nullptr in case something went wrong
-}
-
-} // namespace
-
 namespace mbf_mesh_nav
 {
 using namespace std::placeholders;
 
 MeshNavigationServer::MeshNavigationServer(const TFPtr& tf_listener_ptr, const rclcpp::Node::SharedPtr& node)
-  : AbstractNavigationServer(tf_listener_ptr, node)
+  : SimpleNavigationServer(tf_listener_ptr, node)
   , recovery_plugin_loader_("mbf_mesh_core", "mbf_mesh_core::MeshRecovery")
   , controller_plugin_loader_("mbf_mesh_core", "mbf_mesh_core::MeshController")
   , planner_plugin_loader_("mbf_mesh_core", "mbf_mesh_core::MeshPlanner")
-  , simple_recovery_plugin_loader_("mbf_simple_core", "mbf_simple_core::SimpleRecovery")
-  , simple_controller_plugin_loader_("mbf_simple_core", "mbf_simple_core::SimpleController")
-  , simple_planner_plugin_loader_("mbf_simple_core", "mbf_simple_core::SimplePlanner")
   , mesh_ptr_(new mesh_map::MeshMap(*tf_listener_ptr_, node))
 {
   // advertise services and current goal topic
@@ -149,7 +66,7 @@ MeshNavigationServer::MeshNavigationServer(const TFPtr& tf_listener_ptr, const r
   RCLCPP_INFO_STREAM(node_->get_logger(), "Reading map file...");
   mesh_ptr_->readMap();
 
-  // initialize all plugins
+  // initialize all plugins (done by SimpleNavigationServer constructor) and then initialize the server components (e.g. services) that depend on the plugins to be loaded and initialized
   initializeServerComponents();
 }
 
@@ -179,13 +96,31 @@ mbf_abstract_nav::AbstractRecoveryExecution::Ptr MeshNavigationServer::newRecove
 
 mbf_abstract_core::AbstractPlanner::Ptr MeshNavigationServer::loadPlannerPlugin(const std::string& planner_type)
 {
-  return loadPlugin<mbf_abstract_core::AbstractPlanner>(planner_type, planner_plugin_loader_, simple_planner_plugin_loader_, "planner", node_->get_logger());
+  mbf_abstract_core::AbstractPlanner::Ptr planner_ptr;
+  RCLCPP_INFO(node_->get_logger(), "[MeshNavigationServer] Load global planner plugin.");
+  try
+  {
+    planner_ptr = this->planner_plugin_loader_.createSharedInstance(planner_type);
+  }
+  catch (const pluginlib::PluginlibException &ex)
+  {
+    RCLCPP_FATAL_STREAM(node_->get_logger(), "[MeshNavigationServer] Failed to load the " << planner_type << " planner, are you sure it is properly registered"
+      << " and that the containing library is built? Exception: " << ex.what());
+  }
+
+  if(planner_ptr)
+  {
+    RCLCPP_INFO(node_->get_logger(), "[MeshNavigationServer] Global planner plugin loaded.");
+  }
+  
+  return planner_ptr;
 }
 
-bool MeshNavigationServer::initializePlannerPlugin(const std::string& name,
-                                                   const mbf_abstract_core::AbstractPlanner::Ptr& planner_ptr)
+bool MeshNavigationServer::initializePlannerPlugin(
+  const std::string& name,
+  const mbf_abstract_core::AbstractPlanner::Ptr& planner_ptr)
 {
-  RCLCPP_DEBUG_STREAM(node_->get_logger(), "Initialize planner \"" << name << "\".");
+  RCLCPP_DEBUG_STREAM(node_->get_logger(), "[MeshNavigationServer] Initialize planner \"" << name << "\".");
 
   mbf_mesh_core::MeshPlanner::Ptr mesh_planner_ptr =
       std::dynamic_pointer_cast<mbf_mesh_core::MeshPlanner>(planner_ptr);
@@ -193,32 +128,50 @@ bool MeshNavigationServer::initializePlannerPlugin(const std::string& name,
   {
     if (!mesh_ptr_)
     {
-      RCLCPP_FATAL_STREAM(node_->get_logger(), "The mesh pointer has not been initialized!");
+      RCLCPP_FATAL_STREAM(node_->get_logger(), "[MeshNavigationServer] The mesh pointer has not been initialized!");
       return false;
     }
-    return mesh_planner_ptr->initialize(name, mesh_ptr_, node_);
+    if(mesh_planner_ptr->initialize(name, mesh_ptr_, node_))
+    {
+      RCLCPP_DEBUG_STREAM(node_->get_logger(), "[MeshNavigationServer] Planner plugin \"" << name << "\" initialized.");
+      return true;
+    } else {
+      RCLCPP_ERROR_STREAM(node_->get_logger(), "[MeshNavigationServer] Failed to initialize plugin " << name << ". The plugin's initialize method returned false, which indicates that the plugin failed to initialize itself properly.");
+      return false;
+    }
   }
 
-  mbf_simple_core::SimplePlanner::Ptr simple_planner_ptr =
-    std::dynamic_pointer_cast<mbf_simple_core::SimplePlanner>(planner_ptr);
-  if (simple_planner_ptr) 
-  {
-    simple_planner_ptr->initialize(name, node_);
-    return true;
-  }
-
-  RCLCPP_ERROR_STREAM(node_->get_logger(), "Failed to initialize plugin " << name << ". Looks like it is neither a mesh planner nor a simple planner.");
+  RCLCPP_ERROR_STREAM(node_->get_logger(), "[MeshNavigationServer] Failed to initialize plugin " << name << ". Looks like it is neither a mesh planner nor a simple planner.");
   return false;
 }
 
 mbf_abstract_core::AbstractController::Ptr
 MeshNavigationServer::loadControllerPlugin(const std::string& controller_type)
 {
-  return loadPlugin<mbf_abstract_core::AbstractController>(controller_type, controller_plugin_loader_, simple_controller_plugin_loader_, "controller", node_->get_logger());
+  mbf_abstract_core::AbstractController::Ptr controller_ptr;
+
+  RCLCPP_INFO(node_->get_logger(), "[MeshNavigationServer] Load controller plugin.");
+  try
+  {
+    controller_ptr = this->controller_plugin_loader_.createSharedInstance(controller_type);
+  }
+  catch (const pluginlib::PluginlibException &ex)
+  {
+    RCLCPP_FATAL_STREAM(node_->get_logger(), "[MeshNavigationServer] Failed to load the " << controller_type << " controller, are you sure it is properly registered"
+    << " and that the containing library is built? Exception: " << ex.what());
+  }
+
+  if(controller_ptr)
+  {
+    RCLCPP_INFO(node_->get_logger(), "[MeshNavigationServer] Controller plugin loaded.");
+  }
+
+  return controller_ptr;
 }
 
-bool MeshNavigationServer::initializeControllerPlugin(const std::string& name,
-                                                      const mbf_abstract_core::AbstractController::Ptr& controller_ptr)
+bool MeshNavigationServer::initializeControllerPlugin(
+  const std::string& name,
+  const mbf_abstract_core::AbstractController::Ptr& controller_ptr)
 {
   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Initialize controller \"" << name << "\".");
 
@@ -237,19 +190,17 @@ bool MeshNavigationServer::initializeControllerPlugin(const std::string& name,
       RCLCPP_FATAL_STREAM(node_->get_logger(), "The mesh pointer has not been initialized!");
       return false;
     }
-
-    mesh_controller_ptr->initialize(name, tf_listener_ptr_, mesh_ptr_, node_);
-    RCLCPP_DEBUG_STREAM(node_->get_logger(), "Controller plugin \"" << name << "\" initialized.");
-    return true;
-  }
-
-  mbf_simple_core::SimpleController::Ptr simple_controller_ptr =
-    std::dynamic_pointer_cast<mbf_simple_core::SimpleController>(controller_ptr);
-  if (simple_controller_ptr) 
-  {
-    simple_controller_ptr->initialize(name, tf_listener_ptr_, node_);
-    RCLCPP_DEBUG_STREAM(node_->get_logger(), "Controller plugin \"" << name << "\" initialized.");
-    return true;
+    
+    if(mesh_controller_ptr->initialize(name, tf_listener_ptr_, mesh_ptr_, node_))
+    {
+      RCLCPP_DEBUG_STREAM(node_->get_logger(), "Controller plugin \"" << name << "\" initialized.");
+      return true;
+    }
+    else
+    {
+      RCLCPP_ERROR_STREAM(node_->get_logger(), "Failed to initialize plugin " << name << ". The plugin's initialize method returned false, which indicates that the plugin failed to initialize itself properly.");
+      return false;
+    }
   }
 
   RCLCPP_ERROR_STREAM(node_->get_logger(), "Failed to initialize plugin " << name << ". Looks like it is neither a mesh controller nor a simple controller.");
@@ -258,11 +209,31 @@ bool MeshNavigationServer::initializeControllerPlugin(const std::string& name,
 
 mbf_abstract_core::AbstractRecovery::Ptr MeshNavigationServer::loadRecoveryPlugin(const std::string& recovery_type)
 {
-  return loadPlugin<mbf_abstract_core::AbstractRecovery>(recovery_type, recovery_plugin_loader_, simple_recovery_plugin_loader_, "recovery behavior", node_->get_logger());
+  // return loadPlugin<mbf_abstract_core::AbstractRecovery>(recovery_type, recovery_plugin_loader_, simple_recovery_plugin_loader_, "recovery behavior", node_->get_logger());
+  mbf_abstract_core::AbstractRecovery::Ptr recovery_ptr;
+
+  RCLCPP_INFO(node_->get_logger(), "[MeshNavigationServer] Load recovery behavior plugin.");
+  try
+  {
+    recovery_ptr = this->recovery_plugin_loader_.createSharedInstance(recovery_type);
+  }
+  catch (const pluginlib::PluginlibException &ex)
+  {
+    RCLCPP_FATAL_STREAM(node_->get_logger(), "[MeshNavigationServer] Failed to load the " << recovery_type << " recovery behavior, are you sure it is properly registered"
+      << " and that the containing library is built? Exception: " << ex.what());
+  }
+
+  if(recovery_ptr)
+  {
+    RCLCPP_INFO(node_->get_logger(), "[MeshNavigationServer] Recovery behavior plugin loaded.");
+  }
+
+  return recovery_ptr;
 }
 
-bool MeshNavigationServer::initializeRecoveryPlugin(const std::string& name,
-                                                    const mbf_abstract_core::AbstractRecovery::Ptr& behavior_ptr)
+bool MeshNavigationServer::initializeRecoveryPlugin(
+  const std::string& name,
+  const mbf_abstract_core::AbstractRecovery::Ptr& behavior_ptr)
 {
   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Initialize recovery behavior \"" << name << "\".");
 
@@ -282,18 +253,16 @@ bool MeshNavigationServer::initializeRecoveryPlugin(const std::string& name,
       return false;
     }
 
-    mesh_behavior_ptr->initialize(name, tf_listener_ptr_, mesh_ptr_, node_);
-    RCLCPP_DEBUG_STREAM(node_->get_logger(), "Recovery behavior plugin \"" << name << "\" initialized.");
-    return true;
-  }
-
-  mbf_simple_core::SimpleRecovery::Ptr simple_behavior_ptr =
-    std::dynamic_pointer_cast<mbf_simple_core::SimpleRecovery>(behavior_ptr);
-  if (simple_behavior_ptr) 
-  {
-    simple_behavior_ptr->initialize(name, tf_listener_ptr_, node_);
-    RCLCPP_DEBUG_STREAM(node_->get_logger(), "Recovery behavior plugin \"" << name << "\" initialized.");
-    return true;
+    if(mesh_behavior_ptr->initialize(name, tf_listener_ptr_, mesh_ptr_, node_))
+    {
+      RCLCPP_DEBUG_STREAM(node_->get_logger(), "Recovery behavior plugin \"" << name << "\" initialized.");
+      return true;
+    }
+    else
+    {
+      RCLCPP_ERROR_STREAM(node_->get_logger(), "Failed to initialize plugin " << name << ". The plugin's initialize method returned false, which indicates that the plugin failed to initialize itself properly.");
+      return false;
+    }
   }
 
   RCLCPP_ERROR_STREAM(node_->get_logger(), "Failed to initialize plugin " << name << ". Looks like it is neither a mesh recovery behavior nor a simple recovery behavior.");
@@ -302,7 +271,7 @@ bool MeshNavigationServer::initializeRecoveryPlugin(const std::string& name,
 
 void MeshNavigationServer::stop()
 {
-  AbstractNavigationServer::stop();
+  Base::stop();
   // TODO
   // RCLCPP_INFO_STREAM_NAMED(node_->get_logger(), "mbf_mesh_nav", "Stopping mesh map for shutdown");
   // mesh_ptr_->stop();


### PR DESCRIPTION
Before, the MeshNavigationServer inherited from AbstractNavigationServer and manually managed support for SimpleNavigation plugins. I thought this could be done with less code duplication by just letting the MeshNavigationServer inherit from the SimpleNavigationServer instead. Turns out it works well: both MeshNav and SimpleNav plugins can still be loaded into a MeshNav instance.

Drawback: more error messages.

With the current implementation, the `initializeServerComponents` function in the constructor of the SimpleNavigationServer is invoked first and tries to load all plugins as SimpleNav plugins. This results in some error messages. In the second step, the `initializeServerComponents` function of the MeshNavigationServer constructor is invoked, and all the plugins are then tried to be loaded as MeshNav plugins. Again, there are some errors for those that are not MeshNav plugins.

Possible solutions:

1. Add a constructor flag to optionally disable the call to `initializeServerComponents`, and add all the base class calls to the MeshNavigationServer manually.
2. Invoke the init function after constructing the object. This means we'd have to change something in the node creation part of MBF SimpleNav.
3. Make error messages warning, info or debug